### PR TITLE
fix(package.json): fix repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Prebuilt google-beta Provider for Terraform CDK (cdktf)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashicorp/cdktf-provider-google-beta.git"
+    "url": "https://github.com/hashicorp/cdktf-provider-googlebeta.git"
   },
   "scripts": {
     "build": "npx projen build",


### PR DESCRIPTION
the current url does not match GH repo, links on https://www.npmjs.com/package/@cdktf/provider-google-beta are broken