### PR TITLE
fix(package.json): fix provider registry url

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "cdktf": {
     "provider": {
-      "name": "registry.terraform.io/hashicorp/google-beta",
+      "name": "registry.terraform.io/providers/hashicorp/google-beta",
       "version": "4.27.0"
     }
   },


### PR DESCRIPTION
it was missing `/provider/` in the url and leading to 404 page